### PR TITLE
Update wordpress cmd to fix uploads permissions and apache cmd

### DIFF
--- a/wordpress-volumes/wordpress-web.yml
+++ b/wordpress-volumes/wordpress-web.yml
@@ -13,7 +13,7 @@ spec:
       - name: wordpress
         image: wordpress:4-php7.0
         # uncomment to fix perm issue, see also https://github.com/kubernetes/kubernetes/issues/2630
-        # command: ['bash', '-c', 'chown', 'www-data:www-data', '/var/www/html/wp-content/upload', '&&', 'apache2', '-DFOREGROUND']
+        # command: ['bash', '-c', 'chown www-data:www-data /var/www/html/wp-content/uploads && apache2-foreground']
         ports:
         - name: http-port
           containerPort: 80


### PR DESCRIPTION
The CMD for the wordpress container was no longer correct, It has been updated to the correct chown command and mirror the apache command in the docker file of the wordpress image