### PR TITLE
Fix format for commands in Deploy kubeless

### DIFF
--- a/kubeless/README.md
+++ b/kubeless/README.md
@@ -7,8 +7,10 @@ rm -r bundles/
 ```
 
 # Deploy kubeless
+```
 kubectl create ns kubeless
 kubectl create -f https://github.com/kubeless/kubeless/releases/download/v1.0.2/kubeless-v1.0.2.yaml
+```
 
 # Example function
 


### PR DESCRIPTION
Fix markdown format to set fixed font on kubectl commands