### PR TITLE
Fix role and role binding names

### DIFF
--- a/users/user.yaml
+++ b/users/user.yaml
@@ -2,7 +2,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
-  name: pod-reader
+  name: pod-writer
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -22,5 +22,5 @@ subjects:
   apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: Role
-  name: pod-reader
+  name: pod-writer
   apiGroup: rbac.authorization.k8s.io

--- a/users/user.yaml
+++ b/users/user.yaml
@@ -14,7 +14,7 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: read-pods
+  name: write-pods
   namespace: default
 subjects:
 - kind: User


### PR DESCRIPTION
In the RBAC demo (lecture 87), you have mentioned that the role names should be "writer" instead of "reader" since the role have grants like create and update.